### PR TITLE
Fix(startup): Correct model import in history route

### DIFF
--- a/app/routes/users_modules/history.py
+++ b/app/routes/users_modules/history.py
@@ -4,7 +4,7 @@
 from flask import render_template, request
 from flask_login import login_required
 from sqlalchemy.orm import joinedload
-from app.models import UserAppAccess
+from app.models import User
 from app.models_media_services import MediaStreamHistory
 from app.utils.helpers import permission_required, setup_required
 from . import users_bp
@@ -21,9 +21,7 @@ def general_history():
     # Query all media stream history, ordered by most recent.
     # Eagerly load related user and server info to prevent N+1 queries in the template.
     history_query = MediaStreamHistory.query.options(
-        joinedload(MediaStreamHistory.user_app_access),
-        joinedload(MediaStreamHistory.user_media_access).joinedload('user_app_access'),
-        joinedload(MediaStreamHistory.user_media_access).joinedload('server'),
+        joinedload(MediaStreamHistory.user),
         joinedload(MediaStreamHistory.server)
     ).order_by(MediaStreamHistory.started_at.desc())
 


### PR DESCRIPTION
The application was failing to start due to an `ImportError` for `UserAppAccess` in `app/routes/users_modules/history.py`. This model has been replaced by a unified `User` model.

This change updates the import and the associated database query to use the new `User` model. This also unblocks the database migration process, which failed to run due to the import error, and will resolve the subsequent `sqlite3.OperationalError`.